### PR TITLE
Improve editor load time

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -64,7 +64,17 @@ function onSelectionChange(e) {
  * Ouvre l'éditeur HTML dans une boîte de dialogue ou sidebar
  */
 function openEditor(useDialog = false) {
-  const html = HtmlService.createHtmlOutputFromFile('editor')
+  const sheet = SpreadsheetApp.getActiveSheet();
+  const cell = sheet.getActiveCell();
+  const cellData = {
+    content: cell.getValue() || '',
+    row: cell.getRow(),
+    col: cell.getColumn(),
+  };
+
+  const template = HtmlService.createTemplateFromFile('editor');
+  template.cellData = cellData;
+  const html = template.evaluate()
     .setTitle('Éditeur HTML');
     
   const ui = SpreadsheetApp.getUi();
@@ -99,16 +109,6 @@ function editActiveCellDialog() {
 /**
  * Récupère le contenu de la cellule active
  */
-function getCellContent() {
-  const sheet = SpreadsheetApp.getActiveSheet();
-  const cell = sheet.getActiveCell();
-  return {
-    content: cell.getValue() || '',
-    row: cell.getRow(),
-    col: cell.getColumn()
-  };
-}
-
 /**
  * Sauvegarde le contenu dans la cellule
  */

--- a/editor.html
+++ b/editor.html
@@ -286,19 +286,16 @@
   
   <script>
     let currentTab = 'visual';
-    let cellData = null;
+    let cellData = <?!= JSON.stringify(cellData) ?>;
     let undoStack = [];
     let redoStack = [];
     let maxUndoSteps = 50;
     let isExecutingCommand = false;
-    
+
     // Initialisation
     window.onload = function() {
-      google.script.run
-        .withSuccessHandler(loadContent)
-        .withFailureHandler(showError)
-        .getCellContent();
-        
+      loadContent(cellData);
+
       // Ajouter les écouteurs pour undo/redo
       document.addEventListener('keydown', handleKeyPress);
     };


### PR DESCRIPTION
## Summary
- avoid extra network call by embedding cell info directly into template
- remove unused getCellContent function
- pass cell data to the client via template variables

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6840facb21c8832086018b261bf1dbf7