### PR TITLE
Restrict scrollbar to editable area

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -27,18 +27,24 @@
       box-sizing: border-box;
     }
     
+    html, body {
+      height: 100%;
+    }
+
     body {
       margin: 0;
       padding: 0;
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
       color: var(--text-primary);
       background: #FAFAFA;
+      overflow: hidden;
     }
     
     .editor-wrapper {
       display: flex;
       flex-direction: column;
-      min-height: 100vh;
+      height: 100vh;
+      overflow: hidden;
       position: relative;
       background: white;
     }


### PR DESCRIPTION
## Summary
- ensure body doesn't scroll by setting html/body to 100% height and hiding overflow
- set editor wrapper to fixed height with hidden overflow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684877bc94bc8320b35da45198a3f9e0